### PR TITLE
feat: add more comparison functions

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -10,6 +10,11 @@ pub struct Count {
 
 #[plugin_fn]
 pub fn test() -> FnResult<()> {
+    xtp_test::assert_gt("gt test", 100, 1);
+    xtp_test::assert_lt("lt test", std::f64::MIN, std::f64::MAX);
+    xtp_test::assert_lte("gte test", 'Z', 'a');
+    xtp_test::assert_lte("lte test", 1 / 10, 1 / 10);
+
     // call a function from some Extism plugin (you'll link these up in the CLI command to run the test),
     // passing in some data and getting back a string (`callString` is a helper for string output)
     let Json(res): Json<Count> = xtp_test::call("count_vowels", "some input")?;
@@ -20,7 +25,7 @@ pub fn test() -> FnResult<()> {
     const TARGET_NS: u64 = 5e7 as u64;
     xtp_test::assert(
         "timing count_vowels nanos (10KB input)",
-       time_ns < TARGET_NS,
+        time_ns < TARGET_NS,
         format!("{} > {}", time_ns, TARGET_NS),
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,42 @@ pub fn assert_ne<U: std::fmt::Debug, T: std::fmt::Debug + PartialEq<U>>(
     assert(msg, x != y, format!("Expected {:?} != {:?}", x, y));
 }
 
+/// Assert that `x` is greater than `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+pub fn assert_gt<U: std::fmt::Debug, T: std::fmt::Debug + PartialOrd<U>>(
+    msg: impl AsRef<str>,
+    x: T,
+    y: U,
+) {
+    assert(msg, x > y, format!("Expected {:?} > {:?}", x, y));
+}
+
+/// Assert that `x` is greater than or equal to `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+pub fn assert_gte<U: std::fmt::Debug, T: std::fmt::Debug + PartialOrd<U>>(
+    msg: impl AsRef<str>,
+    x: T,
+    y: U,
+) {
+    assert(msg, x >= y, format!("Expected {:?} >= {:?}", x, y));
+}
+
+/// Assert that `x` is less than `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+pub fn assert_lt<U: std::fmt::Debug, T: std::fmt::Debug + PartialOrd<U>>(
+    msg: impl AsRef<str>,
+    x: T,
+    y: U,
+) {
+    assert(msg, x < y, format!("Expected {:?} < {:?}", x, y));
+}
+
+/// Assert that `x` is less than or equal to `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+pub fn assert_lte<U: std::fmt::Debug, T: std::fmt::Debug + PartialOrd<U>>(
+    msg: impl AsRef<str>,
+    x: T,
+    y: U,
+) {
+    assert(msg, x <= y, format!("Expected {:?} <= {:?}", x, y));
+}
+
 // Create a new test group. NOTE: these cannot be nested and starting a new group will end the last one.
 fn start_group(name: impl AsRef<str>) {
     let name_mem = Memory::from_bytes(name.as_ref()).expect("assert message Extism memory");


### PR DESCRIPTION
Adds and tests the following new functions: 
```rust
xtp_test::assert_gt("gt test", 100, 1);
xtp_test::assert_lt("lt test", std::f64::MIN, std::f64::MAX);
xtp_test::assert_gte("gte test", 'Z', 'a');
xtp_test::assert_lte("lte test", 1 / 10, 1 / 10);
```